### PR TITLE
⚡ Switch to yt-dlp and prefer aac_at encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # yt - fine-tuning the use of youtube-dl
-Download music or video from e.g. YouTube, Soundcloud, Instagram, Facebook. For a full list of supported sites and services, see https://github.com/ytdl-org/youtube-dl/blob/master/docs/supportedsites.md.
+Download music or video from e.g. YouTube, Soundcloud, Instagram, Facebook. For a full list of supported sites and services, see https://github.com/yt-dlp/yt-dlp/blob/master/supportedsites.md.
 
 ![yt](https://user-images.githubusercontent.com/14880945/62221781-86e1b400-b3b2-11e9-873f-2dd323bcf154.gif)
 
@@ -78,7 +78,7 @@ tl;dr:
 NAME
       yt - fine-tuning the use of youtube-dl.  Download music or video from e.g.  YouTube,
       Soundcloud,  Instagram,  Facebook.  For a full list of supported sites and services,
-      see https://github.com/ytdl-org/youtube-dl/blob/master/docs/supportedsites.md
+      see https://github.com/yt-dlp/yt-dlp/blob/master/supportedsites.md.
 
 SYNOPSIS
       yt [OPTIONS] [URL] [URL...]
@@ -151,6 +151,10 @@ OPTIONS
             Set the maximum pixels of the video output.  Ignored when -v is not specified.
             Defaults to 1920px. Constraint is dropped when no formats comply. For portrait
             and landscape videos,  this corresponds to the  height and width respectively.
+
+      -F FRAMES
+            Set the maximum framerate in frames per second. Defaults to 42. Ignored when
+            -v is not specified. Constraint is dropped when no formats comply.
 
       -m
             Use MP4 when merging audio/video streams, keeping video codecs if possible and

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# yt - fine-tuning the use of youtube-dl
+# yt - fine-tuning the use of youtube-dl / yt-dlp
 Download music or video from e.g. YouTube, Soundcloud, Instagram, Facebook. For a full list of supported sites and services, see https://github.com/yt-dlp/yt-dlp/blob/master/supportedsites.md.
 
 ![yt](https://user-images.githubusercontent.com/14880945/62221781-86e1b400-b3b2-11e9-873f-2dd323bcf154.gif)
 
 ## Description
-[yt](https://github.com/ddelange/yt) is a pure-bash command-line tool that optimizes the use of [youtube-dl](https://github.com/ytdl-org/youtube-dl) for audio and videophiles with comprehensive and customizable presets, empirically tested on multiple streams. Maintains a download archive, to prevent duplicates when periodically downloading YouTube playlists or Soundcloud sets. Parses title ("%(artist)s - %(title)s") and retrieves a thumbnail, and injects these into file metadata. Adds the url id of the source to the filename, attempts to bypass geographical restrictions, and more.
+[yt](https://github.com/ddelange/yt) is a pure-bash command-line tool that optimizes the use of [yt-dlp](https://github.com/yt-dlp/yt-dlp) for audio and videophiles with comprehensive and customizable presets, empirically tested on multiple streams. Maintains a download archive, to prevent duplicates when periodically downloading YouTube playlists or Soundcloud sets. Parses title ("%(artist)s - %(title)s") and retrieves a thumbnail, and injects these into file metadata. Adds the url id of the source to the filename, attempts to bypass geographical restrictions, and more.
 
 #### Features include, but are not limited to:
 - Parallel downloads
@@ -16,11 +16,11 @@ Download music or video from e.g. YouTube, Soundcloud, Instagram, Facebook. For 
 - Embedded subtitle tracks
 - Embedded metadata like chapter information and description
 
-The audio streams in converted (video) files from `yt` will generally be of higher quality compared to [online alternatives](https://www.google.nl/search?q=youtube+to+mp3+online), while maintaining a comparable file size. This is achieved by preferring WAV/OPUS source streams, and by converting using the [Fraunhofer FDK AAC codec library](https://trac.ffmpeg.org/wiki/Encode/AAC#fdk_aac) at a bitrate of 256kbit/s (sufficient to encode a full 44.1kHz stream using `libfdk_aac` without losing detail at higher frequencies).
+The audio streams in converted (video) files from `yt` will generally be of higher quality compared to [online alternatives](https://www.google.nl/search?q=youtube+to+mp3+online), while maintaining a comparable file size. This is achieved by preferring WAV/OPUS source streams, and by converting using the [Fraunhofer FDK AAC codec library](https://trac.ffmpeg.org/wiki/Encode/AAC#fdk_aac) or when available the Mac OS Audiotoolbox (even better) at a bitrate of 256kbit/s (sufficient to encode a full 44.1kHz stream without losing detail at higher frequencies, see benchmark [here](https://gist.github.com/ScribbleGhost/54ad17da006e8bba4a1612bd6a64571c?permalink_comment_id=4691994#gistcomment-4691994)).
 [![yt vs online](https://user-images.githubusercontent.com/14880945/62381156-246feb80-b54b-11e9-8445-3890c091d0c3.gif)](https://github.com/alexkay/spek)
 
 ## Installation
-Dependencies are installations of `youtube-dl`, `atomicparsley`, and `ffmpeg` compiled using at least `--with-fdk-aac` (fdk-aac is GPL-incompatible, so this will produce an unredistributable distribution).
+Dependencies are installations of `yt-dlp`, `atomicparsley`, and `ffmpeg` preferably compiled using `--enable-audiotoolbox` on Mac and `--with-fdk-aac` on other operating systems. Note that fdk-aac is GPL-incompatible, so this will produce an unredistributable distribution.
 
 #### OSX
 To install `yt` and its dependencies:
@@ -30,7 +30,7 @@ brew install ddelange/brewformulae/yt
 
 Or manually (if you wish to avoid Homebrew, and install the dependencies yourself):
 - Compile `ffmpeg` [including](https://trac.ffmpeg.org/wiki/CompilationGuide/macOS#Additionaloptions) `--with-fdk-aac`.
-- [Install](https://github.com/ytdl-org/youtube-dl#installation) `youtube-dl`.
+- [Install](https://github.com/yt-dlp/yt-dlp#installation) `yt-dlp`.
 - Install [`atomicparsley`](https://github.com/wez/atomicparsley).
 - Put [`yt`](yt/yt) in your path:
     ```bash
@@ -47,7 +47,7 @@ brew install ddelange/brewformulae/yt
 
 Or manually (if you wish to avoid Homebrew, and install the dependencies yourself):
 - Compile `ffmpeg` including `--with-fdk-aac`. See example instructions, pick your favorite: [[1]](https://seanthegeek.net/455/how-to-compile-and-install-ffmpeg-4-0-on-debian-ubuntu/) [[2]](https://gist.github.com/rafaelbiriba/7f2d7c6f6c3d6ae2a5cb)
-- [Install](https://github.com/ytdl-org/youtube-dl#installation) `youtube-dl`.
+- [Install](https://github.com/yt-dlp/yt-dlp#installation) `yt-dlp`.
 - Install [`atomicparsley`](https://github.com/wez/atomicparsley).
 - Put [`yt`](yt/yt) in your path:
     ```bash
@@ -57,14 +57,14 @@ Or manually (if you wish to avoid Homebrew, and install the dependencies yoursel
     ```
 
 #### Windows
-Easiest would be using the [Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/about), and using instructions above. But since `youtube-dl` has dedicated Windows distributions available, you could try the following:
+Easiest would be using the [Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/about), and using instructions above. But since `yt-dlp` has dedicated Windows distributions available, you could try the following:
 
 [untested, assumes you're running Bash for Windows]
 - [Compile](https://github.com/jb-alvarado/media-autobuild_suite#information) `ffmpeg` including the `non-free tools` (which will contain `libfdk-aac`).
-- Install `youtube-dl`:
-    - [either] Assuming python / python3 and pip / pip3 are installed, run `sudo pip3 install youtube-dl` or `sudo pip3 install youtube-dl` respectively.
-    - [or] Download [youtube-dl.exe](https://yt-dl.org/latest/youtube-dl.exe) and place it in any location on your [PATH](https://en.wikipedia.org/wiki/PATH_%28variable%29).
-- Make sure `youtube-dl` is recognized by your shell by typing `youtube-dl --version`.
+- Install `yt-dlp`:
+    - [either] Assuming python / python3 and pip / pip3 are installed, run `sudo pip3 install yt-dlp` or `sudo pip3 install yt-dlp` respectively.
+    - [or] Download [yt-dlp.exe](https://github.com/yt-dlp/yt-dlp/releases/latest) and place it in any location on your [PATH](https://en.wikipedia.org/wiki/PATH_%28variable%29).
+- Make sure `yt-dlp` is recognized by your shell by typing `yt-dlp --version`.
 - Put [`yt`](yt/yt) in your path.
 
 ## Usage
@@ -76,38 +76,24 @@ tl;dr:
 
 ```
 NAME
-      yt - fine-tuning the use of youtube-dl.  Download music or video from e.g.  YouTube,
-      Soundcloud,  Instagram,  Facebook.  For a full list of supported sites and services,
-      see https://github.com/yt-dlp/yt-dlp/blob/master/supportedsites.md.
+      yt  -  fine-tuning the use of youtube-dl / yt-dlp. Download music or video from e.g.
+      YouTube,  Soundcloud,  Instagram,  Facebook.  For a full list of supported sites and
+      services, see https://github.com/yt-dlp/yt-dlp/blob/master/supportedsites.md.
 
 SYNOPSIS
       yt [OPTIONS] [URL] [URL...]
 
 DESCRIPTION
-      yt is a bash function that optimizes the use of youtube-dl for audio and videophiles
+      yt is a bash function that  optimizes the use of  yt-dlp  for audio and  videophiles
       with comprehensive and customizable presets, empirically tested on multiple streams.
       Maintains a  download archive,  to prevent duplicates when  periodically downloading
       YouTube playlists or Soundcloud sets.  Parses title  ("%(artist)s - %(title)s")  and
       retrieves a thumbnail, and injects these into file metadata.  Adds the url id of the
       source to the filename, and attempts to bypass geographical restrictions.
 
-      youtube-dl  is a command-line program to download videos from  YouTube.com  and many
-      more sites.  It requires the Python interpreter, version 2.6, 2.7, or 3.2+,  and  it
-      is not platform specific.  It should work on your Unix box,  on Windows or on macOS.
-      It is released to the public domain,  which means you can modify it, redistribute it
-      or use it however you like.
-
-REQUIREMENTS
-      installations  of  youtube-dl  (e.g. "brew install youtube-dl")  and ffmpeg compiled
-      with --enable-libfdk-aac (e.g. "brew install ffmpeg --with-fdk-aac").
-
 OPTIONS
       -h, --help
             Print this help text and exit.
-
-      -U
-            Update  youtube-dl  to latest  version  and  exit.  Make  sure  that  you have
-            sufficient permissions (run with sudo if needed).
 
       -s
             Enable silent mode (send stdout to /dev/null).
@@ -115,7 +101,7 @@ OPTIONS
       -S
             Enable sequential mode.  Default behaviour: parallel mode.  The MAXPROCS (env)
             var sets parallelism  (default 4).  To download YouTube playlists in parallel,
-            use e.g. "yt -v $(youtube-dl --get-id --flat-playlist <playlist-url>)".
+            use e.g. "yt -v $(yt-dlp --get-id --flat-playlist <playlist-url>)".
 
       -f
             Force download, even when already recorded in --download-archive.

--- a/yt/yt
+++ b/yt/yt
@@ -2,38 +2,24 @@
 
 yt() {
   local usage="NAME
-      yt - fine-tuning the use of youtube-dl.  Download music or video from e.g.  YouTube,
-      Soundcloud,  Instagram,  Facebook.  For a full list of supported sites and services,
-      see https://github.com/yt-dlp/yt-dlp/blob/master/supportedsites.md.
+      yt  -  fine-tuning the use of youtube-dl / yt-dlp. Download music or video from e.g.
+      YouTube,  Soundcloud,  Instagram,  Facebook.  For a full list of supported sites and
+      services, see https://github.com/yt-dlp/yt-dlp/blob/master/supportedsites.md.
 
 SYNOPSIS
       yt [OPTIONS] [URL] [URL...]
 
 DESCRIPTION
-      yt is a bash function that optimizes the use of youtube-dl for audio and videophiles
+      yt is a bash function that  optimizes the use of  yt-dlp  for audio and  videophiles
       with comprehensive and customizable presets, empirically tested on multiple streams.
       Maintains a  download archive,  to prevent duplicates when  periodically downloading
       YouTube playlists or Soundcloud sets.  Parses title  (\"%(artist)s - %(title)s\")  and
       retrieves a thumbnail, and injects these into file metadata.  Adds the url id of the
       source to the filename, and attempts to bypass geographical restrictions.
 
-      youtube-dl  is a command-line program to download videos from  YouTube.com  and many
-      more sites.  It requires the Python interpreter, version 2.6, 2.7, or 3.2+,  and  it
-      is not platform specific.  It should work on your Unix box,  on Windows or on macOS.
-      It is released to the public domain,  which means you can modify it, redistribute it
-      or use it however you like.
-
-REQUIREMENTS
-      installations  of  youtube-dl  (e.g. \"brew install youtube-dl\")  and ffmpeg compiled
-      with --enable-libfdk-aac (e.g. \"brew install ffmpeg --with-fdk-aac\").
-
 OPTIONS
       -h, --help
             Print this help text and exit.
-
-      -U
-            Update  youtube-dl  to latest  version  and  exit.  Make  sure  that  you have
-            sufficient permissions (run with sudo if needed).
 
       -s
             Enable silent mode (send stdout to /dev/null).
@@ -41,7 +27,7 @@ OPTIONS
       -S
             Enable sequential mode.  Default behaviour: parallel mode.  The MAXPROCS (env)
             var sets parallelism  (default 4).  To download YouTube playlists in parallel,
-            use e.g. \"yt -v \$(youtube-dl --get-id --flat-playlist <playlist-url>)\".
+            use e.g. \"yt -v \$(yt-dlp --get-id --flat-playlist <playlist-url>)\".
 
       -f
             Force download, even when already recorded in --download-archive.
@@ -122,9 +108,14 @@ All rights reserved."
   local AVC=false
   local HDR=false
   local URLS=()
-
-  # TODO
-  # dependency check e.g. $(ffmpeg -codecs | grep -w libfdk_aac)
+  local CODECS=$(ffmpeg -codecs -hide_banner)
+  if echo ${CODECS} | grep -q 'aac_at'; then
+    local ENCODER='aac_at'
+  elif echo ${CODECS} | grep -q 'libfdk_aac'; then
+    local ENCODER='libfdk_aac'
+  else
+    local ENCODER='aac'
+  fi
 
   # TODO
   # ~$ sudo yt -U
@@ -138,9 +129,6 @@ All rights reserved."
   fi
   while getopts ":hUsSfvcD:pka:r:P:mMH" opt; do
     case $opt in
-      U)
-        sudo youtube-dl -U
-        return;;
       h)
         echo "$usage"
         return;;
@@ -277,7 +265,7 @@ All rights reserved."
   fi
 
   # BASE_OPTIONS
-  local BASE_OPTIONS=(--geo-bypass --ignore-config -i -F --no-simulate --verbose)
+  local BASE_OPTIONS=(--geo-bypass --ignore-config -i -F --no-simulate)
   local output_filename="${destination}%(title).200s %(id)s.%(ext)s"
   local download_archive="${destination}downloaded.txt"
   BASE_OPTIONS+=(-o "$output_filename")
@@ -304,7 +292,7 @@ All rights reserved."
     if $HDR; then
       local DOWNLOAD_OPTIONS=(--merge-output-format mkv -f "(${hdr_selector})+(${audio_selector})/${fallback_video_selector}")
     elif $MP4; then
-      local DOWNLOAD_OPTIONS=(--merge-output-format mp4 --postprocessor-args "Merger:-threads 0 -vcodec copy -b:a ${AUDIO_BITRATE}k -ar ${AUDIO_SAMPLING_RATE} -acodec libfdk_aac -cutoff 20000")
+      local DOWNLOAD_OPTIONS=(--merge-output-format mp4 --postprocessor-args "Merger:-threads 0 -vcodec copy -b:a ${AUDIO_BITRATE}k -ar ${AUDIO_SAMPLING_RATE} -acodec ${ENCODER} -cutoff 20000")
       if [ $MAX_PIXELS -gt 1920 ] && ! $SILENT; then
         echo "Maximum resolution is set to ${MAX_PIXELS}, and -m is present. Downloads will be limited to max 1080p on sites that don't provide higher resolution video streams in MP4 container (e.g. YouTube)."
       fi
@@ -318,7 +306,7 @@ All rights reserved."
     fi
     DOWNLOAD_OPTIONS+=(--embed-subs --sub-langs all,-live_chat --sub-format "srt/best")
   else
-    local DOWNLOAD_OPTIONS=(--embed-thumbnail --audio-format m4a --audio-quality ${AUDIO_BITRATE}k --postprocessor-args "ExtractAudio:-ar ${AUDIO_SAMPLING_RATE} -acodec libfdk_aac -cutoff 20000" -x -f "${audio_selector}/best")
+    local DOWNLOAD_OPTIONS=(--embed-thumbnail --audio-format m4a --audio-quality ${AUDIO_BITRATE}k --postprocessor-args "ExtractAudio:-ar ${AUDIO_SAMPLING_RATE} -acodec ${ENCODER} -cutoff 20000" -x -f "${audio_selector}/best")
     if $KEEP_AUDIO; then
       DOWNLOAD_OPTIONS+=(-k)
     fi

--- a/yt/yt
+++ b/yt/yt
@@ -4,7 +4,7 @@ yt() {
   local usage="NAME
       yt - fine-tuning the use of youtube-dl.  Download music or video from e.g.  YouTube,
       Soundcloud,  Instagram,  Facebook.  For a full list of supported sites and services,
-      see https://github.com/ytdl-org/youtube-dl/blob/master/docs/supportedsites.md
+      see https://github.com/yt-dlp/yt-dlp/blob/master/supportedsites.md.
 
 SYNOPSIS
       yt [OPTIONS] [URL] [URL...]
@@ -78,6 +78,10 @@ OPTIONS
             Defaults to 1920px. Constraint is dropped when no formats comply. For portrait
             and landscape videos,  this corresponds to the  height and width respectively.
 
+      -F FRAMES
+            Set the maximum framerate in frames per second. Defaults to 42. Ignored when
+            -v is not specified. Constraint is dropped when no formats comply.
+
       -m
             Use MP4 when merging audio/video streams, keeping video codecs if possible and
             converting audio to 256kbit/s AAC (resolving full 44.1KHz stream). If no merge
@@ -110,9 +114,10 @@ All rights reserved."
   local KEEP_AUDIO=false
   local FORCE=false
   local CUSTOM_AUDIO_BITRATE=false
-  local AUDIO_BITRATE=257
+  local AUDIO_BITRATE=256
   local AUDIO_SAMPLING_RATE=44100
-  local MAX_PIXELS=1280  # Youtube Shorts are max 720x1280 (portrait)
+  local MAX_PIXELS=1280  # Youtube Shorts are 720x1280 (portrait)
+  local MAX_FPS=42
   local MP4=false
   local AVC=false
   local HDR=false
@@ -197,15 +202,30 @@ All rights reserved."
       P)
         case $OPTARG in
           ''|*[!0-9]*)
-            echo "-p: specify pixels as integer. Type \"yt -h\" for more info."
+            echo "-P: specify pixels as integer. Type \"yt -h\" for more info."
             return
             ;;
           *)
             if [ $OPTARG -lt 144 ]; then
-              echo "-p: pixels should not be less than 144px."
+              echo "-P: pixels should not be less than 144px."
               return
             fi
             MAX_PIXELS=$OPTARG
+            ;;
+        esac
+        ;;
+      F)
+        case $OPTARG in
+          ''|*[!0-9]*)
+            echo "-F: specify fps as integer. Type \"yt -h\" for more info."
+            return
+            ;;
+          *)
+            if [ $OPTARG -lt 20 ]; then
+              echo "-F: fps should not be less than 20."
+              return
+            fi
+            MAX_FPS=$OPTARG
             ;;
         esac
         ;;
@@ -257,12 +277,14 @@ All rights reserved."
   fi
 
   # BASE_OPTIONS
-  local BASE_OPTIONS=(--geo-bypass --ignore-config -i)
+  local BASE_OPTIONS=(--geo-bypass --ignore-config -i -F --no-simulate --verbose)
   local output_filename="${destination}%(title).200s %(id)s.%(ext)s"
   local download_archive="${destination}downloaded.txt"
   BASE_OPTIONS+=(-o "$output_filename")
   if ! $FORCE; then
     BASE_OPTIONS+=(--download-archive "$download_archive")
+  else
+    BASE_OPTIONS+=(--force-overwrites)
   fi
   BASE_OPTIONS+=(--add-metadata --metadata-from-title "%(artist)s - %(title)s")
   if ! $PLAYLIST; then
@@ -272,17 +294,17 @@ All rights reserved."
 
   # DOWNLOAD_OPTIONS
   local audio_selector='bestaudio[acodec=opus]/bestaudio[container*=dash]/bestaudio'
-  local px_spec="height<=${MAX_PIXELS}"
-  local hdr_selector="bestvideo[vcodec^=vp9][${px_spec}]/bestvideo[${px_spec}]/bestvideo"
-  local avc_selector="bestvideo[vcodec^=avc][${px_spec}]/bestvideo"'[vcodec!^=vp9]'"[${px_spec}]/bestvideo[ext=mp4]"
-  local av1_selector="bestvideo[vcodec^=av01][${px_spec}]/bestvideo[vcodec^=av][${px_spec}]/bestvideo"'[vcodec!^=vp9]'"[${px_spec}]/bestvideo[ext=mp4]"
-  local default_video_selector="bestvideo[vcodec=vp9][${px_spec}]/bestvideo[vcodec!=vp9.2][${px_spec}]/bestvideo[${px_spec}]/bestvideo"
-  local fallback_video_selector="best[${px_spec}]/best"
+  local px_spec="[height<=${MAX_PIXELS}][fps<=${MAX_FPS}]"
+  local hdr_selector="bestvideo[vcodec~='(vp09|vp9)']${px_spec}/bestvideo${px_spec}/bestvideo"
+  local avc_selector="bestvideo[vcodec^=avc]${px_spec}/bestvideo"'[vcodec!^=vp]'"${px_spec}/bestvideo[ext=mp4]"
+  local av1_selector="bestvideo[vcodec^=av01]${px_spec}/bestvideo[vcodec^=av]${px_spec}/bestvideo"'[vcodec!^=vp]'"${px_spec}/bestvideo[ext=mp4]"
+  local default_video_selector="bestvideo[vcodec~='(vp09.00|vp9)']${px_spec}/bestvideo[vcodec!=vp09.02]${px_spec}/bestvideo${px_spec}/bestvideo"
+  local fallback_video_selector="best${px_spec}/best"
   if $VIDEO_MODE; then
     if $HDR; then
       local DOWNLOAD_OPTIONS=(--merge-output-format mkv -f "(${hdr_selector})+(${audio_selector})/${fallback_video_selector}")
     elif $MP4; then
-      local DOWNLOAD_OPTIONS=(--merge-output-format mp4 --postprocessor-args "-threads 0 -vcodec copy -acodec aac -b:a ${AUDIO_BITRATE}k -ar ${AUDIO_SAMPLING_RATE}")
+      local DOWNLOAD_OPTIONS=(--merge-output-format mp4 --postprocessor-args "Merger:-threads 0 -vcodec copy -b:a ${AUDIO_BITRATE}k -ar ${AUDIO_SAMPLING_RATE} -acodec libfdk_aac -cutoff 20000")
       if [ $MAX_PIXELS -gt 1920 ] && ! $SILENT; then
         echo "Maximum resolution is set to ${MAX_PIXELS}, and -m is present. Downloads will be limited to max 1080p on sites that don't provide higher resolution video streams in MP4 container (e.g. YouTube)."
       fi
@@ -294,34 +316,29 @@ All rights reserved."
     else
       local DOWNLOAD_OPTIONS=(--merge-output-format mkv -f "(${default_video_selector})+(${audio_selector})/${fallback_video_selector}")
     fi
-    DOWNLOAD_OPTIONS+=(--embed-subs --all-subs --sub-format "srt/best")
+    DOWNLOAD_OPTIONS+=(--embed-subs --sub-langs all,-live_chat --sub-format "srt/best")
   else
-    local DOWNLOAD_OPTIONS=(--embed-thumbnail --audio-format m4a --audio-quality ${AUDIO_BITRATE}k --postprocessor-args "-ar ${AUDIO_SAMPLING_RATE}" -x -f "${audio_selector}/best")
+    local DOWNLOAD_OPTIONS=(--embed-thumbnail --audio-format m4a --audio-quality ${AUDIO_BITRATE}k --postprocessor-args "ExtractAudio:-ar ${AUDIO_SAMPLING_RATE} -acodec libfdk_aac -cutoff 20000" -x -f "${audio_selector}/best")
     if $KEEP_AUDIO; then
       DOWNLOAD_OPTIONS+=(-k)
     fi
   fi
 
-
-  # echo available formats for first URL
-  if ! $SILENT; then
-    youtube-dl -F --no-playlist "${URLS[0]}" || return
-  fi
   # debug the command (non-parallel)
-  # a=(youtube-dl "${BASE_OPTIONS[@]}" "${DOWNLOAD_OPTIONS[@]}" "${URLS[@]}")
+  # a=(yt-dlp "${BASE_OPTIONS[@]}" "${DOWNLOAD_OPTIONS[@]}" "${URLS[@]}")
   # echo ${a[@]}
 
   if $PARALLEL; then
     if $SILENT; then
-      printf "\"%s\"\n" "${URLS[@]}" | xargs -n 1 -P ${PARALLELISM} -I{} youtube-dl "${BASE_OPTIONS[@]}" "${DOWNLOAD_OPTIONS[@]}" "{}" > /dev/null
+      printf "\"%s\"\n" "${URLS[@]}" | xargs -n 1 -P ${PARALLELISM} -I{} yt-dlp "${BASE_OPTIONS[@]}" "${DOWNLOAD_OPTIONS[@]}" "{}" > /dev/null
     else
-      printf "\"%s\"\n" "${URLS[@]}" | xargs -n 1 -P ${PARALLELISM} -I{} youtube-dl "${BASE_OPTIONS[@]}" "${DOWNLOAD_OPTIONS[@]}" "{}"
+      printf "\"%s\"\n" "${URLS[@]}" | xargs -n 1 -P ${PARALLELISM} -I{} yt-dlp "${BASE_OPTIONS[@]}" "${DOWNLOAD_OPTIONS[@]}" "{}"
     fi
   else
     if $SILENT; then
-      youtube-dl "${BASE_OPTIONS[@]}" "${DOWNLOAD_OPTIONS[@]}" "${URLS[@]}" > /dev/null
+      yt-dlp "${BASE_OPTIONS[@]}" "${DOWNLOAD_OPTIONS[@]}" "${URLS[@]}" > /dev/null
     else
-      youtube-dl "${BASE_OPTIONS[@]}" "${DOWNLOAD_OPTIONS[@]}" "${URLS[@]}"
+      yt-dlp "${BASE_OPTIONS[@]}" "${DOWNLOAD_OPTIONS[@]}" "${URLS[@]}"
     fi
   fi
 }


### PR DESCRIPTION
- [Benchmark](https://gist.github.com/ScribbleGhost/54ad17da006e8bba4a1612bd6a64571c?permalink_comment_id=4691994#gistcomment-4691994) of libfdk_aac vs aac_at encoders
- Still using CBR@256
- Using -F --no-simulate to output available formats, saves HTTP requests
- Added FPS selector to (by default) skip 60+ fps video sources
- Don't leave lingering subtitle files after merging
- TBD try to figure out how to implement `-f` such that the input files are re-used, but the output file is re-encoded (the old behaviour). Now, `-f` will re-download the input files that were in the folder from a previous `-k` call.